### PR TITLE
Ethernal/issue36/Tooltips-on-mobile-view-are-overflowing

### DIFF
--- a/src/components/TooltipMessage/TooltipMessage.tsx
+++ b/src/components/TooltipMessage/TooltipMessage.tsx
@@ -193,7 +193,7 @@ function TooltipMessage({
 			</TooltipTrigger>
 			<TooltipContent
 				className={cn(
-					'max-sm:max-w-[90vw] max-xs:grid-cols-1 grid grid-cols-2 sm:max-w-[40vw] bg-theme-light-background-secondary rounded-theme-default p-2 opacity-95  border-2 border-theme-accent-muted backdrop-blur-md [&_p]:text-sm [&_p]:mb-0 [&_p]:align-middle [&>img]:pe-2 [&>img]:col-start-1 shadow-lg dark:bg-theme-dark-background-primary dark:text-theme-white dark:border-theme-accent',
+					'max-xs:max-w-[90vw] max-xs:grid max-xs:grid-cols-1 flow-root max-w-[40vw] bg-theme-light-background-secondary rounded-theme-default p-2 opacity-95  border-2 border-theme-accent-muted backdrop-blur-md [&_p]:text-sm [&_p]:mb-0 [&_p]:align-middle [&>img]:pe-2 [&>img]:float-left shadow-lg dark:bg-theme-dark-background-primary dark:text-theme-white dark:border-theme-accent',
 					className,
 				)}
 			>

--- a/src/components/TooltipMessage/TooltipMessage.tsx
+++ b/src/components/TooltipMessage/TooltipMessage.tsx
@@ -193,7 +193,7 @@ function TooltipMessage({
 			</TooltipTrigger>
 			<TooltipContent
 				className={cn(
-					'flow-root max-w-[40vw] bg-theme-light-background-secondary rounded-theme-default p-2 opacity-95  border-2 border-theme-accent-muted backdrop-blur-md [&_p]:text-sm [&_p]:mb-0 [&_p]:align-middle [&>img]:pe-2 [&>img]:float-left shadow-lg dark:bg-theme-dark-background-primary dark:text-theme-white dark:border-theme-accent',
+					'max-sm:max-w-[90vw] max-xs:grid-cols-1 grid grid-cols-2 sm:max-w-[40vw] bg-theme-light-background-secondary rounded-theme-default p-2 opacity-95  border-2 border-theme-accent-muted backdrop-blur-md [&_p]:text-sm [&_p]:mb-0 [&_p]:align-middle [&>img]:pe-2 [&>img]:col-start-1 shadow-lg dark:bg-theme-dark-background-primary dark:text-theme-white dark:border-theme-accent',
 					className,
 				)}
 			>


### PR DESCRIPTION
Tooltip scales better with size without overflowing.

Fixes #36